### PR TITLE
GET /myCalendar and POST /calendar endpoints added

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,19 +4,25 @@ const PORT = 3000;
 
 app.use(express.json());
 
+// Dummy book data
 const books = [
   { id: 1, title: "The Hobbit", author: "J.R.R. Tolkien" },
   { id: 2, title: "1984", author: "George Orwell" },
 ];
 
+// Dummy calendar data
+const calendarEvents = [
+  { id: 1, title: "Field Trip", date: "2025-07-01", ownerId: "student123" },
+  { id: 2, title: "Math Exam", date: "2025-07-05", ownerId: "student123" },
+  { id: 3, title: "Basketball Game", date: "2025-07-10", ownerId: "student456" },
+];
+
 app.post('/login', (req, res) => {
   const { username, password } = req.body;
-  
   res.status(403).json("your login failed");
 });
 
-
-// Routes
+// Book Routes
 app.get('/books', (req, res) => {
   res.json(books);
 });
@@ -51,6 +57,37 @@ app.delete('/books/:id', (req, res) => {
 
   const deleted = books.splice(index, 1);
   res.json(deleted[0]);
+});
+
+// Calendar Route: GET /myCalendar
+app.get('/myCalendar', (req, res) => {
+  const userId = req.query.userId;
+
+  if (!userId) {
+    return res.status(400).json({ error: "Missing userId query parameter" });
+  }
+
+  const myEvents = calendarEvents.filter(event => event.ownerId === userId);
+  res.json(myEvents);
+});
+
+// Calendar Route: POST /calendar
+app.post('/calendar', (req, res) => {
+  const { title, date, ownerId } = req.body;
+
+  if (!title || !date || !ownerId) {
+    return res.status(400).json({ error: "Missing title, date, or ownerId" });
+  }
+
+  const newEvent = {
+    id: calendarEvents.length + 1,
+    title,
+    date,
+    ownerId
+  };
+
+  calendarEvents.push(newEvent);
+  res.status(201).json(newEvent);
 });
 
 app.listen(PORT, () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,6 +1028,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",

--- a/test.http
+++ b/test.http
@@ -1,0 +1,8 @@
+POST http://localhost:3000/calendar
+Content-Type: application/json
+
+{
+  "title": "Meeting",
+  "date": "2025-07-20",
+  "ownerId": "student123"
+}


### PR DESCRIPTION
Add GET /myCalendar and POST /calendar

- GET /myCalendar returns events for a user
- POST /calendar adds a new event with title, date, and ownerId

I added two new API routes to manage calendar events. The GET /myCalendar gets all events for a specific user based on their userId. The POST /calendar allows creating a new event by sending the title, date, and ownerId. Both use arrays to store and retrieve events and data/ I tested the endpoints locally using HTTP requests and they work fine.