### PR TITLE
New way to add calendar events backend

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -26,11 +26,12 @@ CREATE TABLE `calendar` (
   `idcalendar` int NOT NULL AUTO_INCREMENT,
   `start_time` datetime DEFAULT NULL,
   `end_time` datetime DEFAULT NULL,
-  `class_id` int NOT NULL,
+  `class_id` int DEFAULT NULL,
   `event_title` varchar(255) DEFAULT NULL,
   `user_id` int DEFAULT NULL,
+  `description` text,
   PRIMARY KEY (`idcalendar`)
-) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=72 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -39,7 +40,7 @@ CREATE TABLE `calendar` (
 
 LOCK TABLES `calendar` WRITE;
 /*!40000 ALTER TABLE `calendar` DISABLE KEYS */;
-INSERT INTO `calendar` VALUES (58,'2025-07-18 01:30:00','2025-07-18 05:30:00',1,'1',2),(59,'2025-07-16 10:00:00','2025-07-16 11:00:00',2,'2',4),(61,'2025-07-16 01:00:00','2025-07-16 06:30:00',3,'3',2),(64,'2025-07-14 01:30:00','2025-07-14 05:00:00',6,'6',4),(65,'2025-07-25 09:15:00','2025-07-25 11:45:00',9,'Muhammad Hussein',NULL),(66,'2025-07-29 00:30:00','2025-07-29 05:30:00',1,'Science',NULL);
+INSERT INTO `calendar` VALUES (58,'2025-07-18 01:30:00','2025-07-18 05:30:00',1,'1',2,NULL),(59,'2025-07-16 10:00:00','2025-07-16 11:00:00',2,'2',4,NULL),(61,'2025-07-16 01:00:00','2025-07-16 06:30:00',3,'3',2,NULL),(64,'2025-07-14 01:30:00','2025-07-14 05:00:00',6,'6',4,NULL),(65,'2025-07-25 09:15:00','2025-07-25 11:45:00',9,'Muhammad Hussein',NULL,NULL),(66,'2025-07-29 00:30:00','2025-07-29 05:30:00',1,'Science',NULL,NULL),(70,'2025-08-01 08:11:00','2025-08-02 09:12:00',NULL,'IEEEEe',2,'NMAMAMMAMAMMAMMAMAMA');
 /*!40000 ALTER TABLE `calendar` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -61,7 +62,7 @@ CREATE TABLE `class` (
   PRIMARY KEY (`id`),
   KEY `fk_class_user_idx` (`teacher_id`),
   CONSTRAINT `fk_class_user` FOREIGN KEY (`teacher_id`) REFERENCES `user` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=19 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -70,7 +71,7 @@ CREATE TABLE `class` (
 
 LOCK TABLES `class` WRITE;
 /*!40000 ALTER TABLE `class` DISABLE KEYS */;
-INSERT INTO `class` VALUES (11,'Math','10',4,'2025-07-31 20:30:00','2025-08-01 23:45:00','Wed,Thu'),(12,'Physics','11',2,'2025-07-27 18:00:00','2025-12-31 20:00:00','Tue,Fri');
+INSERT INTO `class` VALUES (11,'Math','10',4,'2025-07-31 20:30:00','2025-08-01 23:45:00','Wed,Thu'),(12,'Physics','11',2,'2025-07-27 04:00:00','2026-01-01 08:00:00','Tue,Fri'),(18,'ENG 101','12',2,'2025-08-10 13:30:00','2025-10-10 15:00:00','Tue,Thu');
 /*!40000 ALTER TABLE `class` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -97,7 +98,7 @@ CREATE TABLE `student_class` (
 
 LOCK TABLES `student_class` WRITE;
 /*!40000 ALTER TABLE `student_class` DISABLE KEYS */;
-INSERT INTO `student_class` VALUES (3,11),(3,12),(5,12);
+INSERT INTO `student_class` VALUES (3,11),(5,11),(3,12),(5,12),(5,18);
 /*!40000 ALTER TABLE `student_class` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -121,13 +122,6 @@ CREATE TABLE `user` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
-DROP TABLE IF EXISTS user_activation;
-CREATE TABLE user_activation (
-  user_id INT PRIMARY KEY,
-  token VARCHAR(255) UNIQUE NOT NULL,
-  expires_at DATETIME NOT NULL,
-  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
-);
 
 --
 -- Dumping data for table `user`
@@ -139,6 +133,7 @@ INSERT INTO `user` VALUES (1,'bob','adam','bob.adam@gmail.com','100 mian street'
 /*!40000 ALTER TABLE `user` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
@@ -147,4 +142,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2025-08-08 16:10:46
+-- Dump completed on 2025-08-15 19:35:49

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 import express from 'express';
 import cors from 'cors';
 import db from './db.js'; // promise-based pool
@@ -10,16 +11,6 @@ import fetch from "node-fetch";
 app.use(cors());
 app.use(express.json());
 
-async function setTimeZone() {
-  try {
-    await db.query("SET time_zone = '-06:00'");
-    console.log('MySQL timezone set to CST');
-  } catch (err) {
-    console.error('Failed to set timezone:', err);
-  }
-}
-
-setTimeZone();
 
 //TASKS
 /*
@@ -83,6 +74,42 @@ app.post("/login", async (req, res) => {
   } catch (err) {
     console.error("❌ Login DB Error:", err);
     return res.status(500).json({ success: false, error: "Database error" });
+  }
+});
+
+// POST /api/calendar — add a new calendar event
+app.post('/api/calendar', async (req, res) => {
+  // Accept 'title' and 'description' from the request and map to DB columns
+  const { title, start_time, end_time, class_id, user_id, description } = req.body;
+  const event_title = title;
+  if (!event_title || !start_time || !end_time || !user_id) {
+    return res.status(400).json({ error: 'title, start_time, end_time, and user_id are required' });
+  }
+  try {
+    const [result] = await db.query(
+      'INSERT INTO calendar (event_title, start_time, end_time, class_id, user_id, description) VALUES (?, ?, ?, ?, ?, ?)',
+      [event_title, start_time, end_time, class_id || null, user_id, description || null]
+    );
+    res.status(201).json({ idcalendar: result.insertId, event_title, start_time, end_time, class_id, user_id, description });
+  } catch (err) {
+    res.status(500).json({ error: 'DB error adding calendar event' });
+  }
+});
+
+// DELETE /api/calendar/:id — delete a calendar event by idcalendar
+app.delete('/api/calendar/:id', async (req, res) => {
+  const idcalendar = parseInt(req.params.id);
+  if (!idcalendar) {
+    return res.status(400).json({ error: 'Invalid calendar event id' });
+  }
+  try {
+    const [result] = await db.query('DELETE FROM calendar WHERE idcalendar = ?', [idcalendar]);
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'Calendar event not found' });
+    }
+    res.json({ message: `Calendar event ${idcalendar} deleted successfully` });
+  } catch (err) {
+    res.status(500).json({ error: 'DB error deleting calendar event' });
   }
 });
 
@@ -416,17 +443,15 @@ app.get('/myCalendar', async (req, res) => {
   const { userId } = req.query;
   try {
     const [rows] = await db.query(
-      `SELECT idcalendar AS id, event_title AS title, start_time, end_time, class_id
-       FROM calendar
-       WHERE user_id = ?`,
+      'SELECT idcalendar AS id, event_title AS title, start_time, end_time, class_id, user_id, description FROM calendar WHERE user_id = ?',
       [userId]
     );
     res.json(rows);
   } catch (err) {
+    console.error("Calendar Fetch Error:", err);
     res.status(500).json({ error: 'DB error fetching calendar events' });
   }
 });
-
 
 
 // (Other calendar routes unchanged)

--- a/test.http
+++ b/test.http
@@ -1,2 +1,17 @@
-GET http://localhost:3000/myCalendar?userId=2
-Accept: application/json
+### Add a calendar event
+### Add a calendar event
+POST http://localhost:3000/api/calendar
+Content-Type: application/json
+
+{
+  "title": "Test Event",
+  "start_time": "2025-08-16 10:00:00",
+  "end_time": "2025-08-16 11:00:00",
+  "description": "Test description",
+  "class_id": 1,
+  "user_id": 1
+}
+###
+
+### Delete a calendar event (replace 5 with your event id)
+DELETE http://localhost:3000/api/calendar/68

--- a/test.http
+++ b/test.http
@@ -1,2 +1,2 @@
-### Get students in grade 10
-GET http://localhost:3000/api/students/grade/10
+GET http://localhost:3000/myCalendar?userId=2
+Accept: application/json


### PR DESCRIPTION
Introduces POST /api/calendar to add new calendar events and DELETE /api/calendar/:id to remove events by id. Updates the /myCalendar endpoint to return additional event fields. Test cases for the new endpoints are added to test.http. Removes the MySQL timezone setting logic.